### PR TITLE
Adjustments & fixes enabling ZooKeeper DIGEST-MD5 authentication

### DIFF
--- a/Mechanisms/SaslDigestMd5.cs
+++ b/Mechanisms/SaslDigestMd5.cs
@@ -79,6 +79,20 @@ namespace S22.Sasl.Mechanisms {
 		}
 
 		/// <summary>
+		/// The protocol to use.  If none is specified, this
+		/// implementation uses "imap".
+		/// </summary>
+		string Protocol {
+			get {
+				return Properties.ContainsKey("Protocol") ?
+					Properties["Protocol"] as string : null;
+			}
+			set {
+				Properties["Protocol"] = value;
+			}
+		}
+
+		/// <summary>
 		/// Private constructor for use with Sasl.SaslFactory.
 		/// </summary>
 		private SaslDigestMd5() {
@@ -151,7 +165,10 @@ namespace S22.Sasl.Mechanisms {
 			// Parse the challenge-string and construct the "response-value" from it.
 			string decoded = Encoding.ASCII.GetString(challenge);
 			NameValueCollection fields = ParseDigestChallenge(decoded);
-			string digestUri = "imap/" + fields["realm"];
+			string protocol = Protocol;
+			if (string.IsNullOrEmpty(protocol))
+				protocol = "imap";
+			string digestUri = protocol + "/" + fields["realm"];
 			string responseValue = ComputeDigestResponseValue(fields, Cnonce, digestUri,
 				Username, Password);
 


### PR DESCRIPTION
Hi @smiley22,

I have recently opened https://github.com/ewhauser/zookeeper/pull/38#issue-343389842 which adds initial SASL support to @ewhauser's pure .NET ZooKeeper client.

I used your implementation of `DIGEST-MD5` to test it, and encountered a few interoperability issues which are fixed by the attached patches.

Would you be willing to pull them?

----

On a related note, it would be great to have `GSSAPI` support.  I have found https://github.com/SteveSyfuhs/Kerberos.NET/issues/9, which is very interesting and promising, but still seems to be missing some pieces:

> SASL would be relatively straightforward to build out, though it's not clear how that would tie into GSS APIs.

There is also the possibility of using the MIT Kerberos implementation, for which https://github.com/SIGAN/gssapi already contains P/Invoke stubs. (I don't think it is complete enough for SASL support, but it should be possible to add the missing APIs.)

What do you think?



